### PR TITLE
BOTH: python ✅, python2 ✅, python3 ✅

### DIFF
--- a/.github/workflows/detect_python.yml
+++ b/.github/workflows/detect_python.yml
@@ -43,7 +43,7 @@ jobs:
         echo -n "python "  && python  --version || true
         echo -n "python2 " && python2 --version
         echo -n "python3 " && python3 --version || true
-        npm run ci || true
+        npm run ci
 
     # Let's disable Python 2
     - name: "NONE: python 🚫, python2 🚫, python3 🚫"
@@ -53,7 +53,7 @@ jobs:
         echo -n "python "  && python  --version || true
         echo -n "python2 " && python2 --version || true
         echo -n "python3 " && python3 --version || true
-        npm run ci || true
+        npm run ci
 
     # Let's re-enable Python 3
     - name: "Py3 ONLY: python ✅, python2 🚫, python3 ✅"
@@ -63,7 +63,7 @@ jobs:
         echo -n "python "  && python  --version
         echo -n "python2 " && python2 --version || true
         echo -n "python3 " && python3 --version
-        npm run ci || true
+        npm run ci
 
     - name: Coveralls
       uses: coverallsapp/github-action@master

--- a/.github/workflows/detect_python.yml
+++ b/.github/workflows/detect_python.yml
@@ -53,7 +53,7 @@ jobs:
         echo -n "python "  && python  --version || true
         echo -n "python2 " && python2 --version || true
         echo -n "python3 " && python3 --version || true
-        npm run ci
+        npm run ci || true
 
     # Let's re-enable Python 3
     - name: "Py3 ONLY: python ✅, python2 🚫, python3 ✅"

--- a/.github/workflows/detect_python.yml
+++ b/.github/workflows/detect_python.yml
@@ -11,7 +11,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  detect_python:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/detect_python.yml
+++ b/.github/workflows/detect_python.yml
@@ -1,0 +1,71 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the
+# source code and run tests across different versions of node
+# https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: detect_python
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [12.x, 14.x, 16.x]  # https://nodejs.org/en/about/releases/
+    steps:
+    - run: brew install python-launcher  # just to ensure this does not create conflicts
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+
+    # GitHub Actions defaults to having both Python 2 and 3 installed with `python` always pointing to `python3`
+    - name: "BOTH: python ✅, python2 ✅, python3 ✅"
+      run: |
+        py --list
+        echo -n "python "  && python  --version
+        echo -n "python2 " && python2 --version
+        echo -n "python3 " && python3 --version
+        npm run ci
+
+    # Let's disable Python 3
+    - name: "PY2 ONLY: python 🚫, python2 ✅, python3 🚫"
+      run: |
+        sudo mv /usr/bin/python3.8 /usr/bin/python3.8.disabled
+        py --list
+        echo -n "python "  && python  --version || true
+        echo -n "python2 " && python2 --version
+        echo -n "python3 " && python3 --version || true
+        npm run ci || true
+
+    # Let's disable Python 2
+    - name: "NONE: python 🚫, python2 🚫, python3 🚫"
+      run: |
+        sudo mv /usr/bin/python2.7 /usr/bin/python2.7.disabled
+        py --list || true
+        echo -n "python "  && python  --version || true
+        echo -n "python2 " && python2 --version || true
+        echo -n "python3 " && python3 --version || true
+        npm run ci || true
+
+    # Let's re-enable Python 3
+    - name: "Py3 ONLY: python ✅, python2 🚫, python3 ✅"
+      run: |
+        sudo mv /usr/bin/python3.8.disabled /usr/bin/python3.8
+        py --list
+        echo -n "python "  && python  --version
+        echo -n "python2 " && python2 --version || true
+        echo -n "python3 " && python3 --version
+        npm run ci || true
+
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/detect_python.yml
+++ b/.github/workflows/detect_python.yml
@@ -53,7 +53,7 @@ jobs:
         echo -n "python "  && python  --version || true
         echo -n "python2 " && python2 --version || true
         echo -n "python3 " && python3 --version || true
-        npm run ci || true
+        npm run ci || true  # `|| true` means that we expect this to fail
 
     # Let's re-enable Python 3
     - name: "Py3 ONLY: python ✅, python2 🚫, python3 ✅"


### PR DESCRIPTION
Given that GitHub Actions pre-installs both Python 2 and 3...
We can just disable and re-enable those instances to run four different tests BOTH, PY2-ONLY, NONE, and PY3-ONLY.